### PR TITLE
Add quiet flag to suppress progress output

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ python -m ap_cull_light.cull_lights <source_dir> <reject_dir> --max-hfr 2.5 --ma
 - `--skip-regex REGEX`: Regex pattern to skip files/directories (e.g., 'accept' or 'accept|processed' to skip multiple patterns)
 - `--debug`: Enable debug output
 - `--dryrun`: Perform dry run without moving files
+- `-q, --quiet`: Suppress progress output
 - `--help`: Show help message and exit
 
 ## Installation

--- a/ap_cull_light/cull_lights.py
+++ b/ap_cull_light/cull_lights.py
@@ -101,6 +101,7 @@ def cull_lights(
     skip_pattern: Optional[re.Pattern] = None,
     debug: bool = False,
     dryrun: bool = False,
+    quiet: bool = False,
 ) -> None:
     """
     Cull light frames based on HFR and RMS thresholds.
@@ -114,6 +115,7 @@ def cull_lights(
         skip_pattern: Compiled regex pattern - files matching the pattern will be skipped
         debug: Enable debug output
         dryrun: Perform dry run without actually moving files
+        quiet: Suppress progress output
     """
     # Get metadata for all FITS files
     required_properties: list[str] = (
@@ -127,7 +129,7 @@ def cull_lights(
         filters={"type": "LIGHT"},
         debug=debug,
         profileFromPath=True,
-        printStatus=True,
+        printStatus=not quiet,
     )
 
     # Group files by directory (for batch rejection confirmation)
@@ -310,6 +312,9 @@ def main() -> None:
     parser.add_argument(
         "--dryrun", action="store_true", help="Perform dry run without moving files"
     )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", help="Suppress progress output"
+    )
 
     args = parser.parse_args()
 
@@ -365,6 +370,7 @@ def main() -> None:
         skip_pattern=skip_pattern,
         debug=args.debug,
         dryrun=args.dryrun,
+        quiet=args.quiet,
     )
 
 

--- a/tests/test_cull_lights.py
+++ b/tests/test_cull_lights.py
@@ -949,3 +949,85 @@ class TestMain:
         ):
             with pytest.raises(SystemExit):
                 cull_lights.main()
+
+    @patch("ap_cull_light.cull_lights.cull_lights")
+    def test_main_with_quiet(self, mock_cull, tmp_path):
+        """Test main with --quiet flag."""
+        source_dir = str(tmp_path / "source")
+        reject_dir = str(tmp_path / "reject")
+        (tmp_path / "source").mkdir()
+
+        with patch(
+            "sys.argv",
+            ["cull_lights.py", source_dir, reject_dir, "--max-hfr", "2.5", "--quiet"],
+        ):
+            cull_lights.main()
+
+        call_kwargs = mock_cull.call_args[1]
+        assert call_kwargs["quiet"] is True
+
+    @patch("ap_cull_light.cull_lights.cull_lights")
+    def test_main_with_quiet_short_flag(self, mock_cull, tmp_path):
+        """Test main with -q short flag."""
+        source_dir = str(tmp_path / "source")
+        reject_dir = str(tmp_path / "reject")
+        (tmp_path / "source").mkdir()
+
+        with patch(
+            "sys.argv",
+            ["cull_lights.py", source_dir, reject_dir, "--max-hfr", "2.5", "-q"],
+        ):
+            cull_lights.main()
+
+        call_kwargs = mock_cull.call_args[1]
+        assert call_kwargs["quiet"] is True
+
+
+class TestCullLightsQuiet:
+    """Tests for quiet parameter in cull_lights function."""
+
+    @patch("ap_common.get_filtered_metadata")
+    def test_cull_lights_quiet_suppresses_progress(self, mock_get_metadata, tmp_path):
+        """Test that cull_lights passes printStatus=False when quiet=True."""
+        source_dir = str(tmp_path / "source")
+        reject_dir = str(tmp_path / "reject")
+
+        mock_get_metadata.return_value = {}
+
+        cull_lights.cull_lights(
+            source_dir=source_dir,
+            reject_dir=reject_dir,
+            max_hfr=2.5,
+            max_rms=None,
+            auto_yes_percent=-1,
+            debug=False,
+            dryrun=False,
+            quiet=True,
+        )
+
+        # Verify get_filtered_metadata was called with printStatus=False
+        call_kwargs = mock_get_metadata.call_args[1]
+        assert call_kwargs["printStatus"] is False
+
+    @patch("ap_common.get_filtered_metadata")
+    def test_cull_lights_not_quiet_shows_progress(self, mock_get_metadata, tmp_path):
+        """Test that cull_lights passes printStatus=True when quiet=False."""
+        source_dir = str(tmp_path / "source")
+        reject_dir = str(tmp_path / "reject")
+
+        mock_get_metadata.return_value = {}
+
+        cull_lights.cull_lights(
+            source_dir=source_dir,
+            reject_dir=reject_dir,
+            max_hfr=2.5,
+            max_rms=None,
+            auto_yes_percent=-1,
+            debug=False,
+            dryrun=False,
+            quiet=False,
+        )
+
+        # Verify get_filtered_metadata was called with printStatus=True
+        call_kwargs = mock_get_metadata.call_args[1]
+        assert call_kwargs["printStatus"] is True


### PR DESCRIPTION
## Summary
Add a new `-q/--quiet` command-line flag to suppress progress output during the culling process, providing users with a cleaner console experience when running the tool in automated or batch scenarios.

## Changes
- **CLI argument**: Added `-q, --quiet` flag to the argument parser in `main()`
- **Function parameter**: Added `quiet: bool = False` parameter to the `cull_lights()` function
- **Progress control**: Modified the `get_filtered_metadata()` call to pass `printStatus=not quiet`, allowing users to suppress metadata retrieval progress messages
- **Documentation**: Updated README.md to document the new flag
- **Tests**: Added comprehensive test coverage including:
  - Tests for both long (`--quiet`) and short (`-q`) flag variants
  - Tests verifying that `printStatus` is correctly set to `False` when quiet mode is enabled
  - Tests verifying that `printStatus` is correctly set to `True` when quiet mode is disabled

## Implementation Details
The quiet flag is implemented as a simple boolean that inverts the `printStatus` parameter passed to `get_filtered_metadata()`. When `quiet=True`, progress output is suppressed by setting `printStatus=False`. This maintains backward compatibility as the default behavior (`quiet=False`) preserves the existing verbose output.

https://claude.ai/code/session_01BCVSP3ZPcqfDP3MsRraiLv