### PR TITLE
Replace logging.basicConfig with setup_logging and connect --quiet flag

### DIFF
--- a/ap_cull_light/cull_lights.py
+++ b/ap_cull_light/cull_lights.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import ap_common
+from ap_common.logging_config import setup_logging
 from . import config
 
 # Configure logging
@@ -319,11 +320,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # Configure logging
-    log_level = logging.DEBUG if args.debug else logging.INFO
-    logging.basicConfig(
-        level=log_level,
-        format="%(levelname)s: %(message)s",
-    )
+    setup_logging(name="ap_cull_light", debug=args.debug, quiet=args.quiet)
 
     # Validate at least one threshold is specified
     if args.max_hfr is None and args.max_rms is None:


### PR DESCRIPTION
Replace manual logging.basicConfig() with ap_common's setup_logging() infrastructure. Connect existing --quiet flag to the logging system.

Changes:
- Import setup_logging from ap_common.logging_config
- Replace logging.basicConfig() with setup_logging() call
- Pass quiet=args.quiet parameter to setup_logging()
- Remove log_level variable (setup_logging handles it)

All 38 tests pass.

Addresses ap-base plan: Quiet Mode Support (Phase 3)

Assisted-by: Claude Code (Claude Sonnet 4.5)