### PR TITLE
Refactor output to use progress indicators and formatted summary

### DIFF
--- a/tests/test_cull_lights.py
+++ b/tests/test_cull_lights.py
@@ -63,10 +63,6 @@ class TestRejectImage:
         # Verify move_file was NOT called
         mock_move_file.assert_not_called()
 
-        # Verify output
-        captured = capsys.readouterr()
-        assert "REJECTED" in captured.out
-
     @patch("ap_common.move_file")
     def test_reject_image_dryrun_debug(self, mock_move_file, tmp_path, capsys):
         """Test that reject_image logs debug info in dryrun mode with debug=True."""
@@ -138,8 +134,6 @@ class TestRejectImage:
 
             # Verify error was logged
             mock_logger.error.assert_called_once()
-            captured = capsys.readouterr()
-            assert "ERROR" in captured.out
 
     @patch("ap_common.move_file")
     def test_reject_image_generic_exception(self, mock_move_file, tmp_path, capsys):
@@ -167,8 +161,6 @@ class TestRejectImage:
             # Verify error was logged with exc_info
             mock_logger.error.assert_called_once()
             assert "exc_info" in str(mock_logger.error.call_args)
-            captured = capsys.readouterr()
-            assert "ERROR" in captured.out
 
     def test_reject_image_safety_check(self, tmp_path, monkeypatch):
         """Test that reject_image raises error for invalid destination."""
@@ -292,8 +284,7 @@ class TestCullLights:
 
         # Verify auto-accept message
         captured = capsys.readouterr()
-        assert "automatic" in captured.out.lower()
-        assert "y (automatic" in captured.out
+        assert "auto" in captured.out.lower()
 
     @patch("ap_common.get_filtered_metadata")
     @patch("ap_cull_light.cull_lights.reject_image")
@@ -569,9 +560,9 @@ class TestCullLights:
         # Verify reject_image was NOT called
         mock_reject.assert_not_called()
 
-        # Verify skip message was printed
+        # Verify no files were rejected
         captured = capsys.readouterr()
-        assert "Skipping rejection" in captured.out
+        assert "No files rejected" in captured.out or "0 of" in captured.out
 
     @patch("ap_common.get_filtered_metadata")
     @patch("ap_cull_light.cull_lights.reject_image")


### PR DESCRIPTION
- Add upfront operation summary showing source, thresholds, and mode
- Import progress_iter and Tuple type
- Add progress indicator for directory evaluation phase
- Add progress indicator for file rejection phase
- Remove auto-accept prompt display (silent auto-accept)
- Add formatted summary table grouping by target/filter
- Change reject_image to use logger instead of print for output
- Update tests to match new output format

Assisted-by: Claude Code (claude-sonnet-4-5-20250929)