### PR TITLE
Add test plan and standardize metadata field access

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ This tool is part of the astrophotography pipeline. For comprehensive documentat
 ### Basic Culling
 
 ```powershell
-python -m ap_cull_light.cull_lights <source_dir> <reject_dir> --max-hfr 2.5 --max-rms 2.0
+python -m ap_cull_light <source_dir> <reject_dir> --max-hfr 2.5 --max-rms 2.0
 ```
 
 ### With Auto-Accept Threshold
 
 ```powershell
-python -m ap_cull_light.cull_lights <source_dir> <reject_dir> --max-hfr 2.5 --max-rms 2.0 --auto-accept-percent 5.0
+python -m ap_cull_light <source_dir> <reject_dir> --max-hfr 2.5 --max-rms 2.0 --auto-accept-percent 5.0
 ```
 
 This will automatically accept rejections if less than 5% of images in a directory group are rejected.
@@ -43,13 +43,13 @@ This will automatically accept rejections if less than 5% of images in a directo
 ### Dry Run
 
 ```powershell
-python -m ap_cull_light.cull_lights <source_dir> <reject_dir> --max-hfr 2.5 --max-rms 2.0 --dryrun
+python -m ap_cull_light <source_dir> <reject_dir> --max-hfr 2.5 --max-rms 2.0 --dryrun
 ```
 
 ### Debug Mode
 
 ```powershell
-python -m ap_cull_light.cull_lights <source_dir> <reject_dir> --max-hfr 2.5 --max-rms 2.0 --debug
+python -m ap_cull_light <source_dir> <reject_dir> --max-hfr 2.5 --max-rms 2.0 --debug
 ```
 
 ## Options
@@ -108,13 +108,13 @@ make uninstall
 ### Basic Culling
 
 ```powershell
-python -m ap_cull_light.cull_lights D:\Astrophotography\Data D:\Astrophotography\Reject --max-hfr 2.5 --max-rms 2.0
+python -m ap_cull_light D:\Astrophotography\Data D:\Astrophotography\Reject --max-hfr 2.5 --max-rms 2.0
 ```
 
 ### With Auto-Accept
 
 ```powershell
-python -m ap_cull_light.cull_lights D:\Astrophotography\Data D:\Astrophotography\Reject --max-hfr 2.5 --max-rms 2.0 --auto-accept-percent 3.0
+python -m ap_cull_light D:\Astrophotography\Data D:\Astrophotography\Reject --max-hfr 2.5 --max-rms 2.0 --auto-accept-percent 3.0
 ```
 
 This will automatically accept rejections if less than 3% of images are rejected in a directory group.
@@ -122,7 +122,7 @@ This will automatically accept rejections if less than 3% of images are rejected
 ### Skipping Files with Regex
 
 ```powershell
-python -m ap_cull_light.cull_lights D:\Astrophotography\Data D:\Astrophotography\Reject --max-hfr 2.5 --max-rms 2.0 --skip-regex "accept|processed"
+python -m ap_cull_light D:\Astrophotography\Data D:\Astrophotography\Reject --max-hfr 2.5 --max-rms 2.0 --skip-regex "accept|processed"
 ```
 
 This will skip any files whose path contains "accept" or "processed" (case-sensitive regex matching).
@@ -130,5 +130,5 @@ This will skip any files whose path contains "accept" or "processed" (case-sensi
 ### Dry Run to Test Rules
 
 ```powershell
-python -m ap_cull_light.cull_lights D:\Astrophotography\Data D:\Astrophotography\Reject --max-hfr 2.5 --max-rms 2.0 --dryrun
+python -m ap_cull_light D:\Astrophotography\Data D:\Astrophotography\Reject --max-hfr 2.5 --max-rms 2.0 --dryrun
 ```

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -1,0 +1,111 @@
+# Test Plan
+
+> This document describes the testing strategy for this project. It serves as the single source of truth for testing decisions and rationale.
+
+## Overview
+
+**Project:** ap-cull-light
+**Primary functionality:** Cull astrophotography light frames based on HFR and RMS thresholds
+
+## Testing Philosophy
+
+This project follows the [ap-base Testing Standards](https://github.com/jewzaam/ap-base/blob/main/standards/testing.md).
+
+Key testing principles for this project:
+
+- All external dependencies (ap_common, filesystem) are mocked to ensure unit test isolation
+- Tests verify both success paths and error conditions for file rejection logic
+- Threshold evaluation logic is tested with numeric, non-numeric, and missing values
+
+## Test Categories
+
+### Unit Tests
+
+Tests for isolated functions with mocked dependencies.
+
+| Module | Function | Test Coverage | Notes |
+|--------|----------|---------------|-------|
+| `cull_lights.py` | `reject_image()` | Normal move, dryrun, debug logging, file not under source, OSError, generic exception, path traversal safety | ap_common.move_file is mocked |
+| `cull_lights.py` | `cull_lights()` | HFR/RMS threshold evaluation, auto-accept percent, dryrun, skip pattern, both thresholds, non-numeric values, missing filename, user rejection, multiple directory groups, no rejections, empty data, debug logging | ap_common.get_filtered_metadata is mocked |
+| `cull_lights.py` | `main()` | CLI argument parsing for all options, validation errors (no thresholds, invalid percent, invalid regex, missing source, non-directory source, same source/reject dir), quiet flag | Uses sys.argv patching |
+
+### Integration Tests
+
+Tests for multiple components working together.
+
+| Workflow | Components | Test Coverage | Notes |
+|----------|------------|---------------|-------|
+| Quiet mode | `cull_lights()` + `get_filtered_metadata` | printStatus parameter passing | Verifies quiet flag propagates correctly |
+
+## Untested Areas
+
+| Area | Reason Not Tested |
+|------|-------------------|
+| Actual file I/O (moving files) | ap_common.move_file is mocked; tested in ap-common |
+| FITS/XISF header parsing | ap_common.get_filtered_metadata is mocked; tested in ap-common |
+| Interactive user prompts (real stdin) | Mocked via `builtins.input`; interactive testing not feasible in CI |
+
+## Bug Fix Testing Protocol
+
+All bug fixes to existing functionality **must** follow TDD:
+
+1. Write a failing test that exposes the bug
+2. Verify the test fails before implementing the fix
+3. Implement the fix
+4. Verify the test passes
+5. Verify reverting the fix causes the test to fail again
+6. Commit test and fix together with issue reference
+
+### Regression Tests
+
+| Issue | Test | Description |
+|-------|------|-------------|
+
+## Coverage Goals
+
+**Target:** 80%+ line coverage
+
+**Philosophy:** Coverage measures completeness, not quality. A test that executes code without meaningful assertions provides no value. Focus on:
+
+- Testing behavior, not implementation details
+- Covering edge cases and error conditions
+- Ensuring assertions verify expected outcomes
+
+## Running Tests
+
+```bash
+# Run all tests
+make test
+
+# Run with coverage
+make coverage
+
+# Run specific test
+pytest tests/test_cull_lights.py::TestClass::test_function
+```
+
+## Test Data
+
+Test data is:
+- Generated programmatically in fixtures where possible
+- Created using `tmp_path` pytest fixture for filesystem isolation
+- All metadata dictionaries are constructed inline in test methods
+
+**No Git LFS** - all test data must be small (< 100KB) or generated.
+
+## Maintenance
+
+When modifying this project:
+
+1. **Adding features**: Add tests for new functionality after implementation
+2. **Fixing bugs**: Follow TDD protocol above (test first, then fix)
+3. **Refactoring**: Existing tests should pass without modification (behavior unchanged)
+4. **Removing features**: Remove associated tests
+
+## Changelog
+
+| Date | Change | Rationale |
+|------|--------|-----------|
+| 2026-02-15 | Initial test plan | Project creation |
+
+---

--- a/ap_cull_light/cull_lights.py
+++ b/ap_cull_light/cull_lights.py
@@ -13,7 +13,12 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import ap_common
-from ap_common import NORMALIZED_HEADER_HFR, NORMALIZED_HEADER_RMSAC, TYPE_LIGHT
+from ap_common import (
+    NORMALIZED_HEADER_FILENAME,
+    NORMALIZED_HEADER_HFR,
+    NORMALIZED_HEADER_RMSAC,
+    TYPE_LIGHT,
+)
 from ap_common.logging_config import setup_logging
 from ap_common.progress import progress_iter, ProgressTracker
 from . import config
@@ -205,7 +210,9 @@ def cull_lights(
                             reasons.append(f"HFR={hfr_float} > {max_hfr}")
                     except (ValueError, TypeError):
                         if debug:
-                            filename_for_log = metadata.get("filename", "unknown")
+                            filename_for_log = metadata.get(
+                                NORMALIZED_HEADER_FILENAME, "unknown"
+                            )
                             logger.warning(
                                 f"Skipping HFR check for {filename_for_log}: "
                                 f"non-numeric HFR value '{hfr_value}'"
@@ -222,7 +229,9 @@ def cull_lights(
                             reasons.append(f"RMS={rms_float} > {max_rms} arcsec")
                     except (ValueError, TypeError):
                         if debug:
-                            filename_for_log = metadata.get("filename", "unknown")
+                            filename_for_log = metadata.get(
+                                NORMALIZED_HEADER_FILENAME, "unknown"
+                            )
                             logger.warning(
                                 f"Skipping RMS check for {filename_for_log}: "
                                 f"non-numeric RMS value '{rms_value}'"
@@ -230,7 +239,7 @@ def cull_lights(
 
             if should_reject:
                 count_reject += 1
-                filename = metadata.get("filename")
+                filename = metadata.get(NORMALIZED_HEADER_FILENAME)
                 if filename is None:
                     logger.warning(
                         "Metadata missing 'filename' field, skipping rejection"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ ap-cull-light = "ap_cull_light.cull_lights:main"
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "pytest-mock>=3.0",
     "black>=23.0",
     "flake8>=6.0",
     "mypy==1.11.2",


### PR DESCRIPTION
## Summary
This PR establishes a comprehensive testing strategy for the project and improves code consistency by standardizing how metadata fields are accessed throughout the codebase.

## Key Changes

- **Added TEST_PLAN.md**: Comprehensive testing documentation covering:
  - Testing philosophy aligned with ap-base standards
  - Unit and integration test categories with coverage details
  - Untested areas and rationale
  - Bug fix testing protocol using TDD
  - Coverage goals (80%+) and maintenance guidelines

- **Standardized metadata field access**: Updated `cull_lights.py` to use `NORMALIZED_HEADER_FILENAME` constant instead of hardcoded `"filename"` string:
  - Imported `NORMALIZED_HEADER_FILENAME` from `ap_common`
  - Replaced three instances of `metadata.get("filename")` with `metadata.get(NORMALIZED_HEADER_FILENAME)`
  - Improves maintainability and consistency with other normalized header constants

- **Updated documentation**: Fixed command invocation examples in README.md to use the correct module path (`python -m ap_cull_light` instead of `python -m ap_cull_light.cull_lights`)

- **Added test dependency**: Added `pytest-mock>=3.0` to dev dependencies to support mocking in unit tests

## Implementation Details

The metadata field standardization ensures that if the normalized header constant changes in `ap_common`, this codebase will automatically use the correct field name without requiring manual updates. This follows the same pattern already used for `NORMALIZED_HEADER_HFR` and `NORMALIZED_HEADER_RMSAC`.

https://claude.ai/code/session_01HUd785JxkD2YsgikjFuqUu